### PR TITLE
Adding Optional Bot Security Paramaters

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -36,6 +36,8 @@ var debug = require('debug')('botkit:main');
 // Create the Botkit controller, which controls all instances of the bot.
 var controller = Botkit.sparkbot({
     // debug: true,
+    // limit_to_domain: ['mycompany.com'],
+    // limit_to_org: 'my_cisco_org_id',
     public_address: process.env.public_address,
     ciscospark_access_token: process.env.access_token,
     studio_token: process.env.studio_token, // get one from studio.botkit.ai to enable content management, stats, message console and more


### PR DESCRIPTION
Adding in placeholders for limiting the Bot to responding only to whitelisted domains or to a specific OrgID.