### PR TITLE
save body text for hmac check

### DIFF
--- a/components/express_webserver.js
+++ b/components/express_webserver.js
@@ -7,7 +7,9 @@ module.exports = function(controller, bot) {
 
 
     var webserver = express();
-    webserver.use(bodyParser.json());
+    webserver.use(bodyParser.json({verify: function(req, res, buf, encoding) {
+        req.rawBody = buf.toString();
+    }}));
     webserver.use(bodyParser.urlencoded({ extended: true }));
 
     // import express middlewares that are present in /components/express_middleware


### PR DESCRIPTION
In order to verify the hmac of the Cisco Spark webhook, we need to save the raw body of the request to express.