### PR TITLE
remove SSL required blurb from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ Launch your bot application by typing:
 
 `node .`
 
-Cisco Spark requires your application be available at an SSL-enabled endpoint. To expose an endpoint during development, we recommend using [localtunnel.me](http://localtunnel.me) or [ngrok](http://ngrok.io), either of which can be used to temporarily expose your bot to the internet. Once stable and published to the real internet, use nginx or another web server to provide an SSL-powered front end to your bot application. 
+Cisco Spark requires your application be available at an internet-accessible endpoint. To expose an endpoint during development, we recommend using [localtunnel.me](http://localtunnel.me) or [ngrok](http://ngrok.io), either of which can be used to temporarily expose your bot to the internet. 
 
 Now comes the fun part of [making your bot!](https://github.com/howdyai/botkit/blob/master/docs/readme.md#basic-usage)
 


### PR DESCRIPTION
SSL is not required by Spark webhooks